### PR TITLE
Fix provisioning and testing errors

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,10 +53,10 @@ Setting["place_name"] = "Consul-land"
 # Feature flags
 Setting['feature.debates'] = true
 Setting['feature.spending_proposals'] = true
-Setting['feature.twitter_login'] = false
-Setting['feature.facebook_login'] = false
-Setting['feature.google_login'] = false
+Setting['feature.twitter_login'] = true
+Setting['feature.facebook_login'] = true
+Setting['feature.google_login'] = true
 Setting['feature.saml_login'] = true
 Setting['feature.public_stats'] = true
-Setting['feature.registration'] = false
-Setting['feature.userpassword'] = false
+Setting['feature.registration'] = true
+Setting['feature.userpassword'] = true

--- a/vagrant/00-install-consul-deps.sh
+++ b/vagrant/00-install-consul-deps.sh
@@ -47,6 +47,6 @@ yum install -y nodejs gcc-c++ make
 # Install PhantomJS 2.1.1
 curl -sSL -O https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
 tar -xjvf phantomjs-2.1.1-linux-x86_64.tar.bz2
-cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin
+cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/bin
 rm -fr phantomjs-2.1.1-linux-x86_64
 rm -f phantomjs-2.1.1-linux-x86_64.tar.bz2

--- a/vagrant/01-setup-database.sh
+++ b/vagrant/01-setup-database.sh
@@ -5,6 +5,7 @@ cd /vagrant
 # pg create consul user
 cat <<EOF | sudo -u postgres psql
 CREATE USER consul WITH PASSWORD 'consul' CREATEDB;
+ALTER USER consul WITH SUPERUSER;
 EOF
 
 cat <<EOF | sudo -u postgres psql

--- a/vagrant/02-setup-dev-env.sh
+++ b/vagrant/02-setup-dev-env.sh
@@ -9,6 +9,6 @@ cd /vagrant
 bundle install
 sed -e 's/@pgusername@/consul/' -e 's/@pgpassword@/consul/' config/database.yml.example > config/database.yml
 cp config/secrets.yml.example config/secrets.yml
-bin/rake db:setup
-bin/rake db:dev_seed
-RAILS_ENV=test bin/rake db:setup
+rake db:setup
+rake db:dev_seed
+RAILS_ENV=test rake db:setup


### PR DESCRIPTION
- Seeds were incorrect and were breaking tests.
- phantomjs was being installed outside of $PATH. The executable was moved to /usr/bin/phantomjs.
- bin/rake was causing issue #8, we are now using rake instead.
- At some point postgresql required the user to be a superuser.

Fixes #8 
